### PR TITLE
Fix brew cask categorization parsing

### DIFF
--- a/backup_brew.sh
+++ b/backup_brew.sh
@@ -75,8 +75,10 @@ process_chunk() {
 
     echo "$selected_categories"  # Debugging line
 
-    # Split the response into an array
-    IFS=',' read -r -a categories_array <<< "$selected_categories"
+    # Split the response into an array using newlines as separators
+    # The model returns each "cask, category" pair on its own line, so using
+    # mapfile simplifies parsing and preserves categories with spaces.
+    mapfile -t categories_array <<< "$selected_categories"
 
     # Append casks to the categorized casks CSV file
     for i in "${!casks[@]}"; do


### PR DESCRIPTION
## Summary
- use `mapfile` to read categories from Fabric output

## Testing
- `bash -n backup_brew.sh`


------
https://chatgpt.com/codex/tasks/task_e_68412628f2bc8333b4cbb7c9aba511da